### PR TITLE
Fix references to images in JS.

### DIFF
--- a/app/assets/javascripts/init.js.erb
+++ b/app/assets/javascripts/init.js.erb
@@ -27,7 +27,7 @@ $(document).on('turbolinks:load', function() {
   (function imageresize() {
     if(window.matchMedia(imgbig).matches) {
       $('.change img').each(function () {
-        this.src= "/assets/background2-6492c83fc5943157d9debcd80089e7f7.jpg";
+        this.src = "<%= asset_path 'background2.jpg' %>";
       });
       // swap out small displays for xs displays on smaller screens
       $('.display').removeClass('XS');
@@ -36,7 +36,7 @@ $(document).on('turbolinks:load', function() {
     }
     else if(window.matchMedia(imgsmall).matches) {
       $('.change img').each(function () {
-        this.src= "/assets/background1-a9d15ff618c71c16cc1cc81dc8d8f2f1.jpg";
+        this.src = "<%= asset_path 'background1.jpg' %>";
       });
       // swap out small displays for xs displays on smaller screens
       $('.display').removeClass('S');


### PR DESCRIPTION
We were refering to the images in out JS with the processed hash postfix but
this resulted in broken links to the images.

This works locally at least, will need to check that it also works in production.